### PR TITLE
Map sync services to configured server indices

### DIFF
--- a/NekoNetClient/PlayerData/Factories/PairHandlerFactory.cs
+++ b/NekoNetClient/PlayerData/Factories/PairHandlerFactory.cs
@@ -50,9 +50,17 @@ public class PairHandlerFactory
         {
             if (!string.IsNullOrEmpty(pair.ApiUrlOverride))
             {
-                var urls = _serverConfigManager.GetServerApiUrls();
-                var idx = Array.FindIndex(urls, u => string.Equals(u, pair.ApiUrlOverride, StringComparison.OrdinalIgnoreCase));
-                if (idx >= 0) serverIndex = idx;
+                var resolvedIndex = _serverConfigManager.FindServerIndexByHost(pair.ApiUrlOverride);
+                if (resolvedIndex.HasValue)
+                {
+                    serverIndex = resolvedIndex;
+                }
+                else
+                {
+                    var urls = _serverConfigManager.GetServerApiUrls();
+                    var idx = Array.FindIndex(urls, u => string.Equals(u, pair.ApiUrlOverride, StringComparison.OrdinalIgnoreCase));
+                    if (idx >= 0) serverIndex = idx;
+                }
             }
         }
         catch { }

--- a/NekoNetClient/Services/Mediator/Messages.cs
+++ b/NekoNetClient/Services/Mediator/Messages.cs
@@ -32,7 +32,10 @@ public record CutsceneEndMessage : MessageBase;
 public record CutsceneFrameworkUpdateMessage : SameThreadMessage;
 public record ConnectedMessage(ConnectionDto Connection) : MessageBase;
 public record ConfiguredConnectedMessage(int ServerIndex, ConnectionDto Connection) : MessageBase;
-public record ServiceConnectedMessage(NekoNetClient.WebAPI.SignalR.SyncService Service, ConnectionDto Connection) : MessageBase;
+public record ServiceConnectedMessage(
+    NekoNetClient.WebAPI.SignalR.SyncService Service,
+    ConnectionDto Connection,
+    int? ServerIndex) : MessageBase;
 public record DisconnectedMessage : SameThreadMessage;
 public record PenumbraModSettingChangedMessage : MessageBase;
 public record PenumbraInitializedMessage : MessageBase;

--- a/NekoNetClient/WebAPI/Files/FileTransferOrchestrator.cs
+++ b/NekoNetClient/WebAPI/Files/FileTransferOrchestrator.cs
@@ -67,6 +67,21 @@ public class FileTransferOrchestrator : DisposableMediatorSubscriberBase
             catch { }
         });
 
+        Mediator.Subscribe<ServiceConnectedMessage>(this, (msg) =>
+        {
+            try
+            {
+                if (!msg.ServerIndex.HasValue) return;
+                var cdn = msg.Connection.ServerInfo?.FileServerAddress;
+                if (cdn == null) return;
+
+                _cdnByServerIdx[msg.ServerIndex.Value] = cdn;
+                var hostKey = cdn.IsDefaultPort ? cdn.Host : $"{cdn.Host}:{cdn.Port}";
+                _serverIdxByHost[hostKey] = msg.ServerIndex.Value;
+            }
+            catch { }
+        });
+
         Mediator.Subscribe<DisconnectedMessage>(this, (msg) =>
         {
             FilesCdnUri = null;

--- a/NekoNetClient/WebAPI/SignalR/MultiHubManager.cs
+++ b/NekoNetClient/WebAPI/SignalR/MultiHubManager.cs
@@ -10,7 +10,9 @@ using NekoNetClient.MareConfiguration;
 using NekoNetClient.PlayerData.Factories;
 using NekoNetClient.PlayerData.Pairs;
 using NekoNetClient.Services.Mediator;
+using NekoNetClient.Services.Events;
 using NekoNetClient.Services.ServerConfiguration;
+using NekoNetClient.Utils;
 using Dalamud.Plugin.Services;
 using System;
 using System.Collections.Concurrent;
@@ -47,14 +49,6 @@ namespace NekoNetClient.WebAPI.SignalR
         private readonly ConcurrentDictionary<int, Uri> _cfgCdn = new();
         private readonly ConcurrentDictionary<int, DateTime> _cfgLastPush = new();
 
-        private sealed record ServiceSpec(string Endpoint, bool UseMareToken, bool WebSocketsOnly);
-        private static readonly Dictionary<SyncService, ServiceSpec> ServiceMap = new()
-        {
-            { SyncService.NekoNet,  new ServiceSpec("wss://connect.neko-net.cc/mare",    true,  true) },
-            { SyncService.Lightless, new ServiceSpec("wss://sync.lightless-sync.org/lightless", true, true) },
-            { SyncService.TeraSync, new ServiceSpec("wss://tera.terasync.app/tera-sync-v2", true, true) },
-        };
-
         public MultiHubManager(ILogger<MultiHubManager> logger,
             ServerConfigurationManager servers,
             TokenProvider tokens,
@@ -78,7 +72,7 @@ namespace NekoNetClient.WebAPI.SignalR
 
         public HubConnection? Get(SyncService svc) => _hubs.TryGetValue(svc, out var hub) ? hub : null;
         public HubConnectionState GetState(SyncService svc) => _hubs.TryGetValue(svc, out var hub) ? hub.State : HubConnectionState.Disconnected;
-        public string GetResolvedUrl(SyncService svc) => ServiceMap[svc].Endpoint;
+        public string GetResolvedUrl(SyncService svc) => SyncServiceSpecifications.Get(svc).HubEndpoint;
         public string? GetServiceCdnHost(SyncService svc)
             => _svcCdn.TryGetValue(svc, out var u) ? (u.IsDefaultPort ? u.Host : u.Host + ":" + u.Port) : null;
         public DateTime? GetServiceLastPushUtc(SyncService svc)
@@ -130,8 +124,7 @@ namespace NekoNetClient.WebAPI.SignalR
 
         public int? GetServerIndexForService(SyncService svc)
         {
-            // No fixed mapping in the new configured model; return null
-            return null;
+            return _servers.FindServerIndexByService(svc);
         }
 
         public async Task<(int? Online, string Shard)> GetServiceOnlineAsync(SyncService svc, CancellationToken ct)
@@ -193,15 +186,22 @@ namespace NekoNetClient.WebAPI.SignalR
             return _svcPairManagers.GetOrAdd(svc, s =>
             {
                 var logger = _loggerFactory.CreateLogger<PairManager>();
-                // Derive a stable API base (scheme+host) from the service endpoint for per-service notes/tags
-                var endpoint = ServiceMap[s].Endpoint;
-                string apiBase;
-                try { var u = new Uri(endpoint); apiBase = u.GetLeftPart(UriPartial.Authority).Replace("ws://", "http://").Replace("wss://", "https://"); }
-                catch { apiBase = _servers.CurrentApiUrl; }
+                var apiBase = GetServiceApiBase(s);
                 return new PairManager(logger, _pairFactory, _cfg, Mediator, _contextMenu, apiUrlOverride: apiBase, serviceScoped: true);
             });
         }
 
+        private string GetServiceApiBase(SyncService svc)
+        {
+            try
+            {
+                return SyncServiceSpecifications.Get(svc).ApiBase;
+            }
+            catch
+            {
+                return _servers.CurrentApiUrl.TrimEnd('/');
+            }
+        }
         public PairManager GetPairManagerForConfigured(int serverIndex)
         {
             return _cfgPairManagers.GetOrAdd(serverIndex, idx =>
@@ -219,6 +219,12 @@ namespace NekoNetClient.WebAPI.SignalR
         {
             if (_hubs.TryGetValue(svc, out var hub))
             {
+                try
+                {
+                    Mediator.Publish(new EventMessage(new Event(nameof(MultiHubManager), EventSeverity.Informational,
+                        $"Disconnecting service {svc}") { Server = GetServiceApiBase(svc).ToServerLabel() }));
+                }
+                catch { }
                 try { await hub.StopAsync().ConfigureAwait(false); } catch { }
             }
             _hubs.TryRemove(svc, out _);
@@ -232,6 +238,13 @@ namespace NekoNetClient.WebAPI.SignalR
         {
             if (_cfgHubs.TryGetValue(serverIndex, out var hub))
             {
+                try
+                {
+                    var s = _servers.GetServerByIndex(serverIndex);
+                    Mediator.Publish(new EventMessage(new Event(nameof(MultiHubManager), EventSeverity.Informational,
+                        $"Disconnecting configured server #{serverIndex}") { Server = s.ServerUri.ToServerLabel() }));
+                }
+                catch { }
                 try { await hub.StopAsync().ConfigureAwait(false); } catch { }
             }
             _cfgHubs.TryRemove(serverIndex, out _);
@@ -248,6 +261,7 @@ namespace NekoNetClient.WebAPI.SignalR
         {
             var hub = await BuildHubAsync(svc, CancellationToken.None).ConfigureAwait(false);
             await hub.StartAsync().ConfigureAwait(false);
+            _hubs[svc] = hub;
             await PostConnectBootstrapAsync(svc, hub).ConfigureAwait(false);
             try
             {
@@ -255,17 +269,17 @@ namespace NekoNetClient.WebAPI.SignalR
                 if (conn != null && conn.ServerInfo?.FileServerAddress != null)
                 {
                     _svcCdn[svc] = conn.ServerInfo.FileServerAddress;
-                    Mediator.Publish(new ServiceConnectedMessage(svc, conn));
+                    Mediator.Publish(new ServiceConnectedMessage(svc, conn, GetServiceApiBase(svc)));
                 }
             }
             catch { }
-            _hubs[svc] = hub;
         }
 
         public async Task ConnectConfiguredAsync(int serverIndex)
         {
             var hub = await BuildConfiguredHubAsync(serverIndex, CancellationToken.None).ConfigureAwait(false);
             await hub.StartAsync().ConfigureAwait(false);
+            _cfgHubs[serverIndex] = hub;
             await PostConnectBootstrapConfiguredAsync(serverIndex, hub).ConfigureAwait(false);
             // Get ConnectionDto to obtain FileServerAddress for this configured server
             try
@@ -279,7 +293,6 @@ namespace NekoNetClient.WebAPI.SignalR
                 }
             }
             catch { }
-            _cfgHubs[serverIndex] = hub;
         }
 
         public async Task PushCharacterDataAsync(SyncService svc, CharacterData data, List<UserData> recipients, CensusDataDto? census = null)
@@ -306,13 +319,17 @@ namespace NekoNetClient.WebAPI.SignalR
 
         private async Task<HubConnection> BuildHubAsync(SyncService svc, CancellationToken ct)
         {
-            var (endpoint, spec) = (ServiceMap[svc].Endpoint, ServiceMap[svc]);
+            var spec = SyncServiceSpecifications.Get(svc);
+            var resolvedIndex = GetServerIndexForService(svc);
+
             var builder = new HubConnectionBuilder()
-                .WithUrl(endpoint, opt =>
+                .WithUrl(spec.HubEndpoint, opt =>
                 {
                     opt.Transports = HttpTransportType.WebSockets;
-                    opt.SkipNegotiation = spec.WebSocketsOnly;
-                    opt.AccessTokenProvider = () => _tokens.GetOrUpdateToken(ct);
+                    opt.SkipNegotiation = spec.RequiresWebSockets;
+                    opt.AccessTokenProvider = resolvedIndex.HasValue
+                        ? () => _tokens.GetOrUpdateTokenForServer(resolvedIndex.Value, ct)
+                        : () => _tokens.GetOrUpdateToken(ct);
                 })
                 .WithAutomaticReconnect();
 

--- a/NekoNetClient/WebAPI/SignalR/MultiHubManager.cs
+++ b/NekoNetClient/WebAPI/SignalR/MultiHubManager.cs
@@ -264,13 +264,18 @@ namespace NekoNetClient.WebAPI.SignalR
             await hub.StartAsync().ConfigureAwait(false);
             _hubs[svc] = hub;
             await PostConnectBootstrapAsync(svc, hub).ConfigureAwait(false);
+            var resolvedIndex = GetServerIndexForService(svc);
             try
             {
                 var conn = await GetConnectionInfoAsync(svc, CancellationToken.None).ConfigureAwait(false);
-                if (conn != null && conn.ServerInfo?.FileServerAddress != null)
+                if (conn != null)
                 {
-                    _svcCdn[svc] = conn.ServerInfo.FileServerAddress;
-                    Mediator.Publish(new ServiceConnectedMessage(svc, conn, GetServiceApiBase(svc)));
+                    if (conn.ServerInfo?.FileServerAddress != null)
+                    {
+                        _svcCdn[svc] = conn.ServerInfo.FileServerAddress;
+                    }
+
+                    Mediator.Publish(new ServiceConnectedMessage(svc, conn, resolvedIndex));
                 }
             }
             catch { }

--- a/NekoNetClient/WebAPI/SignalR/MultiHubManager.cs
+++ b/NekoNetClient/WebAPI/SignalR/MultiHubManager.cs
@@ -199,7 +199,8 @@ namespace NekoNetClient.WebAPI.SignalR
             }
             catch
             {
-                return _servers.CurrentApiUrl.TrimEnd('/');
+                var current = _servers.CurrentApiUrl;
+                return SyncServiceSpecifications.TrimTrailingSlashes(current);
             }
         }
         public PairManager GetPairManagerForConfigured(int serverIndex)

--- a/NekoNetClient/WebAPI/SignalR/SyncServiceSpecifications.cs
+++ b/NekoNetClient/WebAPI/SignalR/SyncServiceSpecifications.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using NekoNet.API.Data.Enum;
+
+namespace NekoNetClient.WebAPI.SignalR;
+
+internal static class SyncServiceSpecifications
+{
+    internal sealed record Specification(
+        string HubEndpoint,
+        string ApiPath,
+        bool UseMareToken,
+        bool RequiresWebSockets,
+        IReadOnlyCollection<string> Hosts)
+    {
+        internal string ApiBase
+        {
+            get
+            {
+                if (!Uri.TryCreate(HubEndpoint, UriKind.Absolute, out var uri))
+                    return HubEndpoint;
+
+                var builder = new UriBuilder(uri);
+                if (string.Equals(builder.Scheme, "wss", StringComparison.OrdinalIgnoreCase))
+                    builder.Scheme = "https";
+                else if (string.Equals(builder.Scheme, "ws", StringComparison.OrdinalIgnoreCase))
+                    builder.Scheme = "http";
+
+                builder.Port = -1;
+                builder.Path = "/";
+                builder.Query = string.Empty;
+                builder.Fragment = string.Empty;
+                return builder.Uri.ToString().TrimEnd('/');
+            }
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<SyncService, Specification> _specifications =
+        new ReadOnlyDictionary<SyncService, Specification>(new Dictionary<SyncService, Specification>
+        {
+            {
+                SyncService.NekoNet,
+                Create(
+                    "wss://connect.neko-net.cc/mare",
+                    "/mare",
+                    useMareToken: true,
+                    requiresWebSockets: true)
+            },
+            {
+                SyncService.Lightless,
+                Create(
+                    "wss://sync.lightless-sync.org/lightless",
+                    "/lightless",
+                    useMareToken: true,
+                    requiresWebSockets: true)
+            },
+            {
+                SyncService.TeraSync,
+                Create(
+                    "wss://tera.terasync.app/tera-sync-v2",
+                    "/tera-sync-v2",
+                    useMareToken: true,
+                    requiresWebSockets: true)
+            },
+        });
+
+    public static Specification Get(SyncService service) => _specifications[service];
+
+    public static bool TryGet(SyncService service, out Specification specification)
+        => _specifications.TryGetValue(service, out specification!);
+
+    public static IEnumerable<KeyValuePair<SyncService, Specification>> Enumerate()
+        => _specifications;
+
+    public static bool TryResolveServiceByHost(string? hostOrUrl, out SyncService service)
+    {
+        var normalized = NormalizeHostOrAuthority(hostOrUrl);
+        if (normalized == null)
+        {
+            service = default;
+            return false;
+        }
+
+        foreach (var pair in _specifications)
+        {
+            if (pair.Value.Hosts.Contains(normalized))
+            {
+                service = pair.Key;
+                return true;
+            }
+        }
+
+        service = default;
+        return false;
+    }
+
+    internal static string? NormalizeHostOrAuthority(string? hostOrUrl)
+    {
+        if (string.IsNullOrWhiteSpace(hostOrUrl))
+        {
+            return null;
+        }
+
+        var value = hostOrUrl.Trim();
+        if (!value.Contains("://", StringComparison.Ordinal))
+        {
+            value = value.StartsWith("//", StringComparison.Ordinal)
+                ? "https:" + value
+                : "https://" + value.TrimStart('/');
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+        {
+            return hostOrUrl.Trim().Trim('/').ToLowerInvariant();
+        }
+
+        return NormalizeAuthority(uri);
+    }
+
+    internal static string NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        var normalized = path.Trim();
+        if (normalized.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (!normalized.StartsWith("/", StringComparison.Ordinal))
+        {
+            normalized = "/" + normalized;
+        }
+
+        if (normalized.Length > 1 && normalized.EndsWith("/", StringComparison.Ordinal))
+        {
+            normalized = normalized.TrimEnd('/');
+        }
+
+        return normalized;
+    }
+
+    private static Specification Create(string endpoint, string apiPath, bool useMareToken, bool requiresWebSockets)
+    {
+        var hosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
+        {
+            var authority = NormalizeAuthority(uri);
+            if (!string.IsNullOrEmpty(authority))
+            {
+                hosts.Add(authority);
+            }
+
+            var hostOnly = uri.Host.ToLowerInvariant();
+            hosts.Add(hostOnly);
+        }
+
+        return new Specification(endpoint, NormalizePath(apiPath), useMareToken, requiresWebSockets, hosts);
+    }
+
+    private static string? NormalizeAuthority(Uri uri)
+    {
+        if (string.IsNullOrEmpty(uri.Host))
+        {
+            return null;
+        }
+
+        var host = uri.Host.ToLowerInvariant();
+        var defaultPort = uri.Scheme switch
+        {
+            "http" or "ws" => 80,
+            "https" or "wss" => 443,
+            _ => -1,
+        };
+
+        if (uri.IsDefaultPort || uri.Port == -1 || uri.Port == defaultPort)
+        {
+            return host;
+        }
+
+        return host + ":" + uri.Port.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/NekoNetClient/WebAPI/SignalR/SyncServiceSpecifications.cs
+++ b/NekoNetClient/WebAPI/SignalR/SyncServiceSpecifications.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -31,7 +32,7 @@ internal static class SyncServiceSpecifications
                 builder.Path = "/";
                 builder.Query = string.Empty;
                 builder.Fragment = string.Empty;
-                return builder.Uri.ToString().TrimEnd('/');
+                return TrimTrailingSlashes(builder.Uri.ToString());
             }
         }
     }
@@ -107,12 +108,13 @@ internal static class SyncServiceSpecifications
         {
             value = value.StartsWith("//", StringComparison.Ordinal)
                 ? "https:" + value
-                : "https://" + value.TrimStart('/');
+                : "https://" + TrimLeadingSlashes(value);
         }
 
         if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
         {
-            return hostOrUrl.Trim().Trim('/').ToLowerInvariant();
+            var trimmed = TrimSlashes(hostOrUrl.Trim());
+            return trimmed.ToLowerInvariant();
         }
 
         return NormalizeAuthority(uri);
@@ -131,17 +133,15 @@ internal static class SyncServiceSpecifications
             return string.Empty;
         }
 
-        if (!normalized.StartsWith("/", StringComparison.Ordinal))
+        var trimmed = TrimSlashes(normalized);
+        if (trimmed.Length == 0)
         {
-            normalized = "/" + normalized;
+            return normalized.StartsWith("/", StringComparison.Ordinal) && normalized.Length == 1
+                ? "/"
+                : string.Empty;
         }
 
-        if (normalized.Length > 1 && normalized.EndsWith("/", StringComparison.Ordinal))
-        {
-            normalized = normalized.TrimEnd('/');
-        }
-
-        return normalized;
+        return "/" + trimmed;
     }
 
     private static Specification Create(string endpoint, string apiPath, bool useMareToken, bool requiresWebSockets)
@@ -184,4 +184,44 @@ internal static class SyncServiceSpecifications
 
         return host + ":" + uri.Port.ToString(CultureInfo.InvariantCulture);
     }
+
+    internal static string TrimTrailingSlashes(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var end = value.Length - 1;
+        while (end >= 0 && value[end] == '/')
+        {
+            end--;
+        }
+
+        if (end < 0)
+        {
+            return string.Empty;
+        }
+
+        return end == value.Length - 1 ? value : value.Substring(0, end + 1);
+    }
+
+    private static string TrimLeadingSlashes(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var index = 0;
+        while (index < value.Length && value[index] == '/')
+        {
+            index++;
+        }
+
+        return index == 0 ? value : value.Substring(index);
+    }
+
+    private static string TrimSlashes(string value)
+        => TrimTrailingSlashes(TrimLeadingSlashes(value));
 }


### PR DESCRIPTION
## Summary
- add `SyncServiceSpecifications` to capture canonical sync-service endpoints, normalization helpers, and known host/path metadata
- teach `ServerConfigurationManager` to resolve configured server indices from a `SyncService` or hostname and to reuse the shared service metadata when choosing default API paths
- update `MultiHubManager` and `ServiceSessionView` to reuse the shared specs, fetch server-scoped tokens for service hubs, and show the configured server label in the UI

